### PR TITLE
Fix signed-withdraw-server test

### DIFF
--- a/bin/start-signed-withdraw-server.js
+++ b/bin/start-signed-withdraw-server.js
@@ -51,6 +51,7 @@ app.post('/', (req, res) => {
         memberAddress,
         recipientAddress,
         signature,
+        tokenAddress,
     } = req.body
 
     console.log(`Received request ${memberAddress} -> ${recipientAddress} signature ${signature}`)
@@ -81,11 +82,14 @@ app.post('/', (req, res) => {
         return
     }
 
-    const ethersOptions = {}
+    const ethersOptions = {
+        tokenAddress
+    }
     if (GAS_PRICE_GWEI) { ethersOptions.gasPrice = parseUnits(GAS_PRICE_GWEI, 'gwei') }
 
     const streamrOptions = {
         auth: { privateKey: SERVER_PRIVATE_KEY },
+        tokenAddress,
         dataUnion,
     }
     if (ETHEREUM_URL) { streamrOptions.mainnet = { url: ETHEREUM_URL } }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4272,9 +4272,9 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "streamr-client": {
-      "version": "4.2.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-4.2.0-alpha.13.tgz",
-      "integrity": "sha512-3Wk7UozSkEWhgwri0us5u+eI/o6auYIu3ySY9y5+pGw/GBWV9jJgMJ03BVDFbobKdGdWWsp1TWArt24Oy7FJ0A==",
+      "version": "4.2.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/streamr-client/-/streamr-client-4.2.0-alpha.14.tgz",
+      "integrity": "sha512-cH1ffseqwFc+C1dSYtHQduNWCD7MmG54/dgH0oeRBFiRS/BfOczsq1lt9/TF04ySBY2I3CabMiN5I4Q6QT4epg==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@ethersproject/address": "5.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "debug": "^4.3.1",
     "ethers": "^5.0.22",
     "express": "^4.17.1",
-    "streamr-client": "4.2.0-alpha.13",
+    "streamr-client": "4.2.0-alpha.14",
     "yargs": "^15.1.0"
   },
   "devDependencies": {

--- a/test/signed-withdraw-server.js
+++ b/test/signed-withdraw-server.js
@@ -156,6 +156,7 @@ it.skip('Signed withdraw server successfully withdraws earnings', async function
         dataUnionAddress: dataUnion.address,
         memberAddress: memberWallet.address,
         recipientAddress: member2Wallet.address,
+        tokenAddress,
         signature,
     })
     log(`curl -X POST -H "Content-Type: application/json" -d '${body}' ${serverUrl}`)


### PR DESCRIPTION
streamr-client-javascript should be modified so that it can also dig it from a data union if given

alpha.14 version should have that modification but it apparently doesn't work. This should be fixed in the js-client.